### PR TITLE
fix(dast): add cmd_options to OWASP ZAP Baseline Scan step

### DIFF
--- a/.github/workflows/deploy-to-s3.yml
+++ b/.github/workflows/deploy-to-s3.yml
@@ -88,3 +88,4 @@ jobs:
         with:
           target: 'https://amrit.cloud'
           fail_action: false
+          cmd_options: '-a'


### PR DESCRIPTION
Fixing ZAP Automation Framework summary file access error.