### PR TITLE
fix: Update Cognito callback URL to /login

### DIFF
--- a/docs/Authentication_Architecture.md
+++ b/docs/Authentication_Architecture.md
@@ -49,7 +49,7 @@ window.location.href = url;
 
 ### B. Handling the Redirect
 
-After a successful Google login, Cognito redirects the user back to `/admin` with the token embedded in the URL hash fragment (`#id_token=...&access_token=...`).
+After a successful Google login, Cognito redirects the user back to `/login` with the token embedded in the URL hash fragment (`#id_token=...&access_token=...`).
 
 The application automatically parses the URL hash fragment on mount:
 

--- a/infra/modules/backend/cognito.tf
+++ b/infra/modules/backend/cognito.tf
@@ -29,8 +29,8 @@ resource "aws_cognito_user_pool_client" "client" {
   allowed_oauth_scopes                 = ["email", "openid", "profile"]
 
   callback_urls = [
-    "https://amrit.cloud/admin",
-    "http://localhost:3000/admin"
+    "https://amrit.cloud/login",
+    "http://localhost:3000/login"
   ]
   logout_urls = [
     "https://amrit.cloud/",


### PR DESCRIPTION
This PR resolves the Cognito redirect_mismatch error by correctly updating the allowed callback URLs in Terraform to . It also updates the Authentication Architecture documentation to reflect this change.