### PR TITLE
fix: Remove unused imports breaking CI build

### DIFF
--- a/src/pages/admin/AdminDashboard.js
+++ b/src/pages/admin/AdminDashboard.js
@@ -7,15 +7,9 @@ import {
   updateBlog,
   deleteBlog,
   fetchBlogs,
-  loginAdmin,
-  signupAdmin,
   getStoredToken,
   getStoredUser,
   clearSession,
-  verifyEmail,
-  requestPasswordReset,
-  resetPassword,
-  setSession,
 } from "../../utils/apiClient";
 import { marked } from "marked";
 import "./AdminDashboard.css";


### PR DESCRIPTION
Removes unused API client imports from AdminDashboard.js that were causing the production build pipeline to fail.