### PR TITLE
fix: Pass Google OAuth secrets to Terraform

### DIFF
--- a/.github/workflows/infra-apply.yml
+++ b/.github/workflows/infra-apply.yml
@@ -15,6 +15,8 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_REGION: ${{ secrets.AWS_REGION }}
+      TF_VAR_google_client_id: ${{ secrets.GOOGLE_CLIENT_ID }}
+      TF_VAR_google_client_secret: ${{ secrets.GOOGLE_CLIENT_SECRET }}
       TERRAGRUNT_NON_INTERACTIVE: true
 
     steps:


### PR DESCRIPTION
The previous Infrastructure Apply GitHub Action failed because Terraform was not receiving the `TF_VAR_google_client_id` and `TF_VAR_google_client_secret` environment variables from GitHub Secrets. This PR injects those secrets into the action's environment so Terraform can successfully update the Cognito Identity Provider.