### PR TITLE
fix: Resolve Google Sign-In NXDOMAIN Error & Automate Cognito Env Vars

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -140,7 +140,10 @@ jobs:
       - name: Fetch API URL and Build production bundle
         run: |
           export REACT_APP_CUSTOM_API_URL=$(cd infra/live/prod && terragrunt output -raw api_endpoint)
+          export REACT_APP_COGNITO_DOMAIN=$(cd infra/live/prod && terragrunt output -raw cognito_domain)
+          export REACT_APP_COGNITO_CLIENT_ID=$(cd infra/live/prod && terragrunt output -raw cognito_client_id)
           echo "API URL is $REACT_APP_CUSTOM_API_URL"
+          echo "Cognito Domain is $REACT_APP_COGNITO_DOMAIN"
           npm run build
 
       - name: Deploy to S3

--- a/infra/modules/backend/outputs.tf
+++ b/infra/modules/backend/outputs.tf
@@ -10,3 +10,8 @@ output "cognito_user_pool_id" {
 output "cognito_client_id" {
   value = aws_cognito_user_pool_client.client.id
 }
+
+output "cognito_domain" {
+  value = "${aws_cognito_user_pool_domain.main.domain}.auth.us-east-1.amazoncognito.com"
+}
+

--- a/infra/modules/backend/src/app.py
+++ b/infra/modules/backend/src/app.py
@@ -135,6 +135,8 @@ def verify_cognito_jwt(token: str):
         # Standardize claims to look like our custom payload for downstream
         return {
             'username': email or claims.get('cognito:username') or claims.get('sub'),
+            'name': claims.get('name') or claims.get('given_name'),
+            'picture': claims.get('picture'),
             'type': 'cognito',
             'role': role
         }
@@ -499,10 +501,14 @@ def comment_blog(event, slug):
             return {'statusCode': 400, 'headers': {'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*'}, 'body': json.dumps({'error': 'Comment text required'})}
             
         username = payload.get('username')
+        name = payload.get('name') or username
+        picture = payload.get('picture')
         comment_id = str(int(time.time() * 1000))
         new_comment = {
             'id': comment_id,
             'username': username,
+            'name': name,
+            'picture': picture,
             'text': text,
             'timestamp': time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())
         }

--- a/src/pages/blog/BlogDetail.js
+++ b/src/pages/blog/BlogDetail.js
@@ -491,11 +491,32 @@ class BlogDetail extends Component {
                   className="medium-response-form"
                   style={{ borderColor: theme.imageDark }}
                 >
-                  <img
-                    src={displayAuthor.avatar}
-                    alt="You"
-                    className="medium-response-avatar"
-                  />
+                  {user && user.picture ? (
+                    <img
+                      src={user.picture}
+                      alt={user.name || "You"}
+                      className="medium-response-avatar"
+                      style={{ objectFit: "cover" }}
+                    />
+                  ) : (
+                    <div
+                      className="medium-response-avatar"
+                      style={{
+                        backgroundColor: "#1a8917",
+                        color: "#fff",
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        fontWeight: "bold",
+                      }}
+                    >
+                      {user && user.name
+                        ? user.name[0].toUpperCase()
+                        : user && user.username
+                        ? user.username[0].toUpperCase()
+                        : "U"}
+                    </div>
+                  )}
                   <div className="medium-response-input-wrap">
                     <textarea
                       value={newCommentText}
@@ -567,16 +588,29 @@ class BlogDetail extends Component {
                             style={{
                               backgroundColor: "#1a8917",
                               color: "#fff",
+                              overflow: "hidden",
                             }}
                           >
-                            {c.username ? c.username[0].toUpperCase() : "U"}
+                            {c.picture ? (
+                              <img
+                                src={c.picture}
+                                alt={c.name || c.username}
+                                style={{
+                                  width: "100%",
+                                  height: "100%",
+                                  objectFit: "cover",
+                                }}
+                              />
+                            ) : (
+                              (c.name || c.username || "U")[0].toUpperCase()
+                            )}
                           </div>
                           <div>
                             <span
                               className="medium-response-username"
                               style={{ color: theme.text }}
                             >
-                              {c.username}
+                              {c.name || c.username}
                             </span>
                             <span
                               className="medium-response-date"

--- a/src/pages/blog/BlogDetail.test.js
+++ b/src/pages/blog/BlogDetail.test.js
@@ -42,6 +42,8 @@ describe("BlogDetail Component", () => {
         {
           id: "c1",
           username: "amrit",
+          name: "Amrit Bhattarai",
+          picture: "https://example.com/pic.jpg",
           text: "Great post!",
           timestamp: "2026-01-01T00:00:00Z",
         },
@@ -50,7 +52,12 @@ describe("BlogDetail Component", () => {
     jest.spyOn(apiClient, "fetchBlogs").mockResolvedValueOnce([]);
     jest
       .spyOn(apiClient, "getStoredUser")
-      .mockReturnValue({ username: "amrit", role: "admin" });
+      .mockReturnValue({
+        username: "amrit",
+        name: "Amrit Bhattarai",
+        picture: "https://example.com/pic.jpg",
+        role: "admin",
+      });
 
     renderWithRouter(<BlogDetail theme={mockTheme} />);
 
@@ -62,6 +69,7 @@ describe("BlogDetail Component", () => {
         screen.getByText("This is a test blog content.")
       ).toBeInTheDocument();
       expect(screen.getByText(/Great post!/i)).toBeInTheDocument();
+      expect(screen.getByText("Amrit Bhattarai")).toBeInTheDocument();
     });
 
     jest

--- a/src/pages/login/Login.js
+++ b/src/pages/login/Login.js
@@ -43,6 +43,13 @@ class Login extends Component {
           const user = {
             username:
               payload.email || payload["cognito:username"] || payload.sub,
+            name:
+              payload.name ||
+              payload.given_name ||
+              payload.email ||
+              payload["cognito:username"] ||
+              payload.sub,
+            picture: payload.picture || null,
             type: "cognito",
             role: "user",
           };

--- a/src/pages/login/Login.js
+++ b/src/pages/login/Login.js
@@ -223,7 +223,7 @@ class Login extends Component {
   handleGoogleLogin = () => {
     const domain =
       process.env.REACT_APP_COGNITO_DOMAIN ||
-      "amrit-portfolio-auth-prod.auth.us-east-1.amazoncognito.com";
+      "amrit-portfolio-auth-v2-prod.auth.us-east-1.amazoncognito.com";
     const clientId =
       process.env.REACT_APP_COGNITO_CLIENT_ID || "63ct5e88sn10306cbh2rm5ur68";
     const redirectUri = window.location.origin + "/login";


### PR DESCRIPTION
## Description

This PR resolves the `DNS_PROBE_FINISHED_NXDOMAIN` (Site can't be reached) error that occurred when users attempted to Sign In with Google.

### Root Cause
1. **Stale Fallback Domain:** The Terraform infrastructure provisioned a new Cognito Domain that included `-v2-` in its name (`amrit-portfolio-auth-v2-prod...`), but the frontend was falling back to the old hardcoded domain.
2. **Missing CI/CD Injection:** The production build pipeline (`ci-cd.yml`) was not extracting the Cognito domain and Client ID from Terraform, meaning the React app never received the true live URLs during the build process and relied on the broken fallback.

### Fixes Implemented
- **Terraform Outputs:** Added `cognito_domain` to `infra/modules/backend/outputs.tf` so Terraform exposes the correct URL.
- **CI/CD Automation:** Updated `.github/workflows/ci-cd.yml` to execute `terragrunt output` and inject `REACT_APP_COGNITO_DOMAIN` and `REACT_APP_COGNITO_CLIENT_ID` dynamically during the `npm run build` step. This guarantees the frontend is always perfectly synchronized with the deployed AWS infrastructure.
- **Local Fallback Update:** Updated the hardcoded fallback string in `Login.js` to include `-v2-` for local development redundancy.