### PR TITLE
fix: pass COGNITO_CLIENT_ID to lambda env vars to fix 401 Unauthorized

### DIFF
--- a/infra/modules/backend/main.tf
+++ b/infra/modules/backend/main.tf
@@ -76,6 +76,7 @@ resource "aws_lambda_function" "api_lambda" {
       SENDER_EMAIL         = var.admin_email
       COGNITO_USER_POOL_ID = aws_cognito_user_pool.pool.id
       COGNITO_REGION       = data.aws_region.current.name
+      COGNITO_CLIENT_ID    = aws_cognito_user_pool_client.client.id
     }
   }
 }


### PR DESCRIPTION
## Description

This PR fixes the `401 Unauthorized` error that occurs when trying to publish a comment after logging in with Google.

### Root Cause
The backend Lambda function was missing the `COGNITO_CLIENT_ID` environment variable. When the PyJWT library attempts to decode and verify the Cognito ID Token, it requires the `audience` (which maps to the Client ID) to validate the token. Because it was missing, the validation failed silently, and the API fell back to returning a `401 Unauthorized` response.

### Fix
Added `COGNITO_CLIENT_ID` into the `aws_lambda_function.api_lambda` environment variables block in `infra/modules/backend/main.tf`. This ensures the Python backend can successfully verify the token's audience.