### PR TITLE
feat: display user name instead of email in comments

### DIFF
--- a/infra/modules/backend/cognito.tf
+++ b/infra/modules/backend/cognito.tf
@@ -59,5 +59,7 @@ resource "aws_cognito_identity_provider" "google" {
   attribute_mapping = {
     email    = "email"
     username = "sub"
+    name     = "name"
+    picture  = "picture"
   }
 }

--- a/src/pages/blog/BlogDetail.js
+++ b/src/pages/blog/BlogDetail.js
@@ -610,7 +610,9 @@ class BlogDetail extends Component {
                               className="medium-response-username"
                               style={{ color: theme.text }}
                             >
-                              {c.name || c.username}
+                              {c.name ||
+                                (c.username && c.username.split("@")[0]) ||
+                                "User"}
                             </span>
                             <span
                               className="medium-response-date"

--- a/src/pages/blog/BlogDetail.js
+++ b/src/pages/blog/BlogDetail.js
@@ -610,9 +610,7 @@ class BlogDetail extends Component {
                               className="medium-response-username"
                               style={{ color: theme.text }}
                             >
-                              {c.name ||
-                                (c.username && c.username.split("@")[0]) ||
-                                "User"}
+                              {c.name || c.username?.split("@")[0] || "User"}
                             </span>
                             <span
                               className="medium-response-date"


### PR DESCRIPTION
This maps the `name` and `picture` attributes from Google to AWS Cognito, so the backend can capture them. It also updates the frontend to format the fallback username properly (e.g. `john@gmail.com` will display as `john` if the name attribute is completely missing from older comments).