### PR TITLE
fix: block unauthenticated comments caused by Cognito JWT error bypass

### DIFF
--- a/infra/modules/backend/src/app.py
+++ b/infra/modules/backend/src/app.py
@@ -458,9 +458,14 @@ def authenticate(event):
     headers = event.get('headers', {})
     auth_header = headers.get('authorization', headers.get('Authorization', ''))
     token = auth_header.replace('Bearer ', '').strip() if auth_header.startswith('Bearer ') else auth_header
+    if not token:
+        return None
     payload = verify_jwt(token)
     if not payload:
         payload = verify_cognito_jwt(token)
+        if payload and 'error' in payload:
+            print(f"Authentication failed: {payload['error']}")
+            return None
     return payload
 
 def like_blog(event, slug):


### PR DESCRIPTION
This fixes a critical security bug introduced in PR #50 where invalid/expired tokens returned an error dict instead of `None`. Because dicts evaluate to truthy in Python, the `authenticate()` check was bypassed and users with expired tokens could post unauthenticated comments.