### PR TITLE
docs: add agent rule

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -1,0 +1,3 @@
+# Blog Writing Guidelines
+
+- When writing or editing blog posts, avoid using hyphens (`-`) or double underscores (`__`) in sentences as punctuation (e.g., as em dashes) because they can cause rendering issues or formatting conflicts in the UI. Instead, use commas, parentheses, or format the sentence to avoid them entirely. Note that hyphens used in standard markdown lists are fine, but avoid them as inline punctuation within sentences.


### PR DESCRIPTION
Adds the agent rule to avoid hyphens and double underscores in blog content.