### PR TITLE
fix: correct avatar image in blog list

### DIFF
--- a/src/pages/blog/BlogList.js
+++ b/src/pages/blog/BlogList.js
@@ -155,7 +155,7 @@ class BlogList extends Component {
             >
               <div className="medium-sidebar-author">
                 <img
-                  src="https://avatars.githubusercontent.com/u/79965355?v=4"
+                  src={require("../../assests/images/amrit-pp.jpg")}
                   alt="Amrit Bhattarai"
                   className="medium-sidebar-avatar"
                 />


### PR DESCRIPTION
Updates the avatar in the blog list sidebar to use the correct local image rather than the hardcoded GitHub avatar.