### PR TITLE
fix: enforce coverImage validation and fallback rendering

### DIFF
--- a/src/components/blogCard/BlogCard.js
+++ b/src/components/blogCard/BlogCard.js
@@ -8,12 +8,15 @@ export default function BlogCard({ blog, theme }) {
     summary,
     publishDate,
     slug,
-    coverImage: imageUrl,
+    coverImage,
     tags,
     readTime,
     likes,
     comments,
   } = blog;
+
+  const imageUrl =
+    coverImage || "https://amrit.cloud/media/blog_default_cover.png";
 
   const displayAuthor = {
     name: "Amrit Bhattarai",
@@ -62,13 +65,14 @@ export default function BlogCard({ blog, theme }) {
           >
             {formattedDate}{" "}
             {blog.updatedAt &&
-              `(Last updated: ${new Date(
-                blog.updatedAt
-              ).toLocaleDateString("en-US", {
-                month: "short",
-                day: "numeric",
-                year: "numeric",
-              })})`}
+              `(Last updated: ${new Date(blog.updatedAt).toLocaleDateString(
+                "en-US",
+                {
+                  month: "short",
+                  day: "numeric",
+                  year: "numeric",
+                }
+              )})`}
           </span>
         </div>
 

--- a/src/pages/admin/AdminDashboard.js
+++ b/src/pages/admin/AdminDashboard.js
@@ -542,8 +542,17 @@ class AdminDashboard extends Component {
 
   handlePublish = async (e) => {
     e.preventDefault();
-    this.setState({ isPublishing: true, statusMessage: "Publishing…" });
     const { formData, editingSlug } = this.state;
+
+    if (!formData.coverImage) {
+      this.setState({
+        statusMessage: "A cover image is required before publishing.",
+        statusType: "error",
+      });
+      return;
+    }
+
+    this.setState({ isPublishing: true, statusMessage: "Publishing…" });
     const token = getStoredToken();
     const payload = {
       slug: formData.slug,

--- a/src/pages/admin/AdminDashboard.test.js
+++ b/src/pages/admin/AdminDashboard.test.js
@@ -24,6 +24,7 @@ const mockBlogs = [
     title: "Test Blog 1",
     summary: "Summary 1",
     publishDate: "2026-01-01",
+    coverImage: "https://example.com/cover1.png",
     likes: ["user1", "user2"],
     comments: [{ id: 1, text: "nice" }],
   },
@@ -96,6 +97,12 @@ describe("AdminDashboard Component", () => {
     const contentArea = screen.getByPlaceholderText(/Write your story/i);
     fireEvent.change(contentArea, {
       target: { name: "content", value: "This is my story." },
+    });
+
+    // Cover image URL
+    const coverUrlInput = screen.getByPlaceholderText("https://...");
+    fireEvent.change(coverUrlInput, {
+      target: { value: "https://example.com/cover.png" },
     });
 
     // Click publish now (it starts disabled, so we have to ensure it's enabled by having all required fields, which we do)

--- a/src/pages/blog/BlogDetail.js
+++ b/src/pages/blog/BlogDetail.js
@@ -201,6 +201,9 @@ class BlogDetail extends Component {
       readTime,
       summary,
     } = blog;
+
+    const displayCoverImage =
+      coverImage || "https://amrit.cloud/media/blog_default_cover.png";
     const displayAuthor = {
       name: "Amrit Bhattarai",
       avatar: require("../../assests/images/amrit-pp.jpg"),
@@ -426,10 +429,10 @@ class BlogDetail extends Component {
             />
 
             {/* Cover Image */}
-            {coverImage && (
+            {displayCoverImage && (
               <figure className="medium-article-cover">
                 <img
-                  src={coverImage}
+                  src={displayCoverImage}
                   alt={title}
                   className="medium-article-cover-img"
                 />
@@ -696,13 +699,19 @@ class BlogDetail extends Component {
                         borderColor: theme.imageDark,
                       }}
                     >
-                      {rb.coverImage && (
-                        <img
-                          src={rb.coverImage}
-                          alt={rb.title}
-                          className="medium-related-thumb"
-                        />
-                      )}
+                      <div className="medium-related-image">
+                        {(rb.coverImage ||
+                          "https://amrit.cloud/media/blog_default_cover.png") && (
+                          <img
+                            src={
+                              rb.coverImage ||
+                              "https://amrit.cloud/media/blog_default_cover.png"
+                            }
+                            alt={rb.title}
+                            className="medium-related-thumb"
+                          />
+                        )}
+                      </div>
                       <div className="medium-related-meta">
                         <span
                           className="medium-related-tag"


### PR DESCRIPTION
This PR adds client-side validation to the Admin Dashboard to enforce that a cover image is provided when publishing a blog. It also adds a default fallback image to `BlogCard.js` and `BlogDetail.js`.