### PR TITLE
style: improve markdown image aspect ratio and text justification

### DIFF
--- a/src/pages/blog/BlogDetail.css
+++ b/src/pages/blog/BlogDetail.css
@@ -244,6 +244,7 @@
 
 .markdown-body img {
   max-width: 100%;
+  height: auto;
   border-radius: 4px;
   margin: 2em 0;
 }

--- a/src/pages/blog/BlogDetail.css
+++ b/src/pages/blog/BlogDetail.css
@@ -234,6 +234,7 @@
 
 .markdown-body p {
   margin-bottom: 1.8em;
+  text-align: justify;
 }
 
 .markdown-body a {


### PR DESCRIPTION
This PR adds `height: auto` to markdown images to prevent aspect ratio distortion when scaled, and adds `text-align: justify` to markdown paragraphs for a cleaner reading experience.