### PR TITLE
feat: native mobile share experience

### DIFF
--- a/src/pages/blog/BlogDetail.css
+++ b/src/pages/blog/BlogDetail.css
@@ -630,11 +630,28 @@
 /* ===== Responsive ===== */
 @media (max-width: 900px) {
   .medium-engagement-bar {
-    display: none;
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    top: auto;
+    padding: 12px 0;
+    margin: 0;
+    flex-direction: row;
+    justify-content: center;
+    gap: 40px;
+    z-index: 1000;
+    box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.05);
+    border-top: 1px solid rgba(0, 0, 0, 0.05);
+  }
+
+  .medium-engagement-item {
+    flex-direction: row;
+    gap: 8px;
   }
 
   .medium-article-layout {
-    padding: 32px 16px 60px;
+    padding: 32px 16px 90px;
   }
 
   .medium-article-title {

--- a/src/pages/blog/BlogDetail.js
+++ b/src/pages/blog/BlogDetail.js
@@ -227,8 +227,11 @@ class BlogDetail extends Component {
         <Header theme={theme} />
 
         <div className="medium-article-layout">
-          {/* Floating Left Engagement Bar */}
-          <div className="medium-engagement-bar">
+          {/* Floating Engagement Bar (or bottom bar on mobile) */}
+          <div
+            className="medium-engagement-bar"
+            style={{ backgroundColor: theme.body }}
+          >
             {/* Like */}
             <div className="medium-engagement-item">
               <button

--- a/src/pages/blog/BlogDetail.js
+++ b/src/pages/blog/BlogDetail.js
@@ -122,10 +122,28 @@ class BlogDetail extends Component {
     }
   };
 
-  handleShareLink = () => {
-    navigator.clipboard.writeText(window.location.href);
-    this.setState({ linkCopied: true });
-    setTimeout(() => this.setState({ linkCopied: false }), 2000);
+  handleShareLink = async () => {
+    const { blog } = this.state;
+    if (!blog) return;
+
+    const shareUrl = `https://amrit.cloud/blogs/${blog.slug}`;
+    const shareData = {
+      title: blog.title,
+      text: blog.summary,
+      url: shareUrl,
+    };
+
+    if (navigator.share) {
+      try {
+        await navigator.share(shareData);
+      } catch (err) {
+        console.error("Error sharing:", err);
+      }
+    } else {
+      navigator.clipboard.writeText(shareUrl);
+      this.setState({ linkCopied: true });
+      setTimeout(() => this.setState({ linkCopied: false }), 2000);
+    }
   };
 
   scrollToComments = () => {

--- a/src/pages/blog/BlogDetail.test.js
+++ b/src/pages/blog/BlogDetail.test.js
@@ -246,9 +246,43 @@ describe("BlogDetail Component", () => {
 
     const shareBtn = screen.getByTitle("Copy link");
     fireEvent.click(shareBtn);
-    expect(navigator.clipboard.writeText).toHaveBeenCalled();
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      "https://amrit.cloud/blogs/test-blog"
+    );
 
     // Trigger scroll
     fireEvent.scroll(window, { target: { scrollY: 100 } });
+  });
+
+  it("handles sharing the blog post via navigator.share if supported", async () => {
+    const originalShare = global.navigator.share;
+    global.navigator.share = jest.fn().mockResolvedValue(true);
+
+    const testBlog = {
+      slug: "test-blog-2",
+      title: "Test Blog 2",
+      summary: "Test summary",
+      content: "Content",
+    };
+
+    jest.spyOn(apiClient, "fetchBlogBySlug").mockResolvedValueOnce(testBlog);
+    jest.spyOn(apiClient, "fetchBlogs").mockResolvedValueOnce([testBlog]);
+
+    renderWithRouter(<BlogDetail theme={mockTheme} />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Test Blog 2")[0]).toBeInTheDocument();
+    });
+
+    const shareBtn = screen.getByTitle("Copy link");
+    fireEvent.click(shareBtn);
+
+    expect(global.navigator.share).toHaveBeenCalledWith({
+      title: "Test Blog 2",
+      text: "Test summary",
+      url: "https://amrit.cloud/blogs/test-blog-2",
+    });
+
+    global.navigator.share = originalShare;
   });
 });


### PR DESCRIPTION
Updates the share button to use the native Web Share API (`navigator.share`) on supported devices, providing a robust OS-level share sheet (iMessage, WhatsApp, Twitter, etc.). Also ensures the canonical URL (`https://amrit.cloud/blogs/...`) is explicitly generated rather than relying on `window.location.href`, fixing the 'wrong URL copied' bug. Includes test cases to verify both native and fallback copy-to-clipboard functionality.