### PR TITLE
ci: optimize pipeline to skip infrastructure apply

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -11,8 +11,34 @@ permissions:
   actions: write
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      infra: ${{ steps.filter.outputs.infra }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Check paths
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            infra:
+              - 'infra/**'
+              - '.github/workflows/**'
+            frontend:
+              - 'src/**'
+              - 'public/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - '.github/workflows/**'
+
   infrastructure:
     name: Infrastructure Apply
+    needs: changes
+    if: ${{ needs.changes.outputs.infra == 'true' }}
     runs-on: ubuntu-latest
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -104,7 +130,11 @@ jobs:
 
   frontend:
     name: Build & Deploy Frontend
-    needs: infrastructure
+    needs: [changes, infrastructure]
+    if: |
+      always() && 
+      (needs.changes.outputs.frontend == 'true' || needs.changes.outputs.infra == 'true') &&
+      (needs.infrastructure.result == 'success' || needs.infrastructure.result == 'skipped')
     runs-on: ubuntu-latest
     env:
       BUCKET: amrit.cloud


### PR DESCRIPTION
Uses `dorny/paths-filter` to detect changes and skip the heavy `Infrastructure Apply` job if there are no changes to the `infra/` directory. The `Build & Deploy Frontend` job runs intelligently depending on what changed.