### PR TITLE
docs: draft Blog 20 (CRA to Vite) & fix Vite env vars

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -177,11 +177,11 @@ jobs:
 
       - name: Fetch API URL and Build production bundle
         run: |
-          export REACT_APP_CUSTOM_API_URL=$(cd infra/live/prod && terragrunt output -raw api_endpoint)
-          export REACT_APP_COGNITO_DOMAIN=$(cd infra/live/prod && terragrunt output -raw cognito_domain)
-          export REACT_APP_COGNITO_CLIENT_ID=$(cd infra/live/prod && terragrunt output -raw cognito_client_id)
-          echo "API URL is $REACT_APP_CUSTOM_API_URL"
-          echo "Cognito Domain is $REACT_APP_COGNITO_DOMAIN"
+          export VITE_CUSTOM_API_URL=$(cd infra/live/prod && terragrunt output -raw api_endpoint)
+          export VITE_COGNITO_DOMAIN=$(cd infra/live/prod && terragrunt output -raw cognito_domain)
+          export VITE_COGNITO_CLIENT_ID=$(cd infra/live/prod && terragrunt output -raw cognito_client_id)
+          echo "API URL is $VITE_CUSTOM_API_URL"
+          echo "Cognito Domain is $VITE_COGNITO_DOMAIN"
           npm run build
 
       - name: Deploy to S3

--- a/src/components/softwareSkills/SoftwareSkill.tsx
+++ b/src/components/softwareSkills/SoftwareSkill.tsx
@@ -38,7 +38,7 @@ const SoftwareSkill = (props: any) => {
                       <img
                         className="skill-image"
                         style={logo.style}
-                        src={`${process.env.PUBLIC_URL}/skills/${logo.imageSrc}`}
+                        src={`${import.meta.env.BASE_URL}skills/${logo.imageSrc}`}
                         alt={logo.skillName}
                       />
                     )}

--- a/src/pages/contact/ContactComponent.tsx
+++ b/src/pages/contact/ContactComponent.tsx
@@ -96,8 +96,7 @@ function Contact(props: any) {
     };
 
     const baseApiUrl =
-      process.env.REACT_APP_CUSTOM_API_URL ||
-      process.env.REACT_APP_API_URL ||
+      import.meta.env.VITE_CUSTOM_API_URL ||
       "";
     const apiUrl = `${baseApiUrl}/portfolio`;
 

--- a/src/serviceWorker.ts
+++ b/src/serviceWorker.ts
@@ -26,9 +26,9 @@ type Config = {
 };
 
 export function register(config?: Config) {
-  if (process.env.NODE_ENV === "production" && "serviceWorker" in navigator) {
+  if (import.meta.env.MODE === "production" && "serviceWorker" in navigator) {
     // The URL constructor is available in all browsers that support SW.
-    const publicUrl = new URL(process.env.PUBLIC_URL as string, window.location.href);
+    const publicUrl = new URL(import.meta.env.BASE_URL, window.location.href);
     if (publicUrl.origin !== window.location.origin) {
       // Our service worker won't work if PUBLIC_URL is on a different origin
       // from what our page is served on. This might happen if a CDN is used to
@@ -37,7 +37,7 @@ export function register(config?: Config) {
     }
 
     window.addEventListener("load", () => {
-      const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`;
+      const swUrl = `${import.meta.env.BASE_URL}service-worker.js`;
 
       if (isLocalhost) {
         // This is running on localhost. Let's check if a service worker still exists or not.

--- a/src/utils/apiClient.test.tsx
+++ b/src/utils/apiClient.test.tsx
@@ -2,7 +2,7 @@
 let apiClient: typeof import('./apiClient');
 
 beforeAll(async () => {
-  process.env.REACT_APP_CUSTOM_API_URL = "https://test.com";
+  vi.stubEnv("VITE_CUSTOM_API_URL", "https://test.com");
   apiClient = await import("./apiClient");
 });
 
@@ -106,8 +106,7 @@ describe("apiClient", () => {
       ok: true,
       json: async () => [{ slug: "test" }],
     });
-    // Need to set REACT_APP_CUSTOM_API_URL or it will return mock
-    process.env.REACT_APP_CUSTOM_API_URL = "https://localhost";
+    // Need to set VITE_CUSTOM_API_URL or it will return mock (already set in beforeAll)
     const res = await apiClient.fetchBlogs();
     expect(res).toBeTruthy();
   });
@@ -498,8 +497,7 @@ describe("apiClient API unreachable", () => {
 
   it("getMediaUploadUrl returns mock when API_URL is null", async () => {
     // temporarily unset API_URL
-    const originalApi = process.env.REACT_APP_CUSTOM_API_URL;
-    delete process.env.REACT_APP_CUSTOM_API_URL;
+    vi.unstubAllEnvs();
 
     // We need to re-require the module to apply the null API_URL
     vi.resetModules();
@@ -511,12 +509,11 @@ describe("apiClient API unreachable", () => {
     expect(res.cloudfront_url).toContain("mock");
 
     // restore
-    process.env.REACT_APP_CUSTOM_API_URL = originalApi;
+    vi.stubEnv("VITE_CUSTOM_API_URL", "https://test.com");
   });
 
   it("uploadMediaToS3 mock mode", async () => {
-    const originalApi = process.env.REACT_APP_CUSTOM_API_URL;
-    delete process.env.REACT_APP_CUSTOM_API_URL;
+    vi.unstubAllEnvs();
     vi.resetModules();
     const newApiClient = await import("./apiClient");
 
@@ -528,7 +525,7 @@ describe("apiClient API unreachable", () => {
     expect(progressSpy).toHaveBeenCalledWith(100);
     expect(res.url).toContain("mock");
 
-    process.env.REACT_APP_CUSTOM_API_URL = originalApi;
+    vi.stubEnv("VITE_CUSTOM_API_URL", "https://test.com");
   });
 
   it("getMediaUploadUrl returns error if response not ok", async () => {

--- a/src/utils/apiClient.ts
+++ b/src/utils/apiClient.ts
@@ -2,10 +2,7 @@
 // We fetch from the custom API deployed via API Gateway
 import amritPic from "../assests/images/amrit-pp.jpg";
 
-const API_URL =
-  typeof process !== "undefined" && process.env
-    ? process.env.REACT_APP_CUSTOM_API_URL
-    : null;
+const API_URL = import.meta.env.VITE_CUSTOM_API_URL || null;
 
 const TOKEN_KEY = "admin_auth_token";
 const USER_KEY = "admin_user_info";


### PR DESCRIPTION
## Description
- Fixes the bug where blogs were missing after the Vite migration by correctly using `import.meta.env.VITE_` instead of `process.env.REACT_APP_`.
- Drafts Blog 20 locally detailing the architectural differences between CRA/Webpack and Vite, and the environment variable migration strategy.