### PR TITLE
chore: add missing .gitmodules for design-dna skill

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".agents/skills/design-dna"]
+	path = .agents/skills/design-dna
+	url = https://github.com/zanwei/design-dna.git


### PR DESCRIPTION
## Description
- Adds the missing `.gitmodules` file to configure the `.agents/skills/design-dna` submodule.
- Fixes the `exit code 128` error in GitHub Actions caused by the checkout step failing to parse a submodule without a remote URL.