### PR TITLE
fix: restrict bandit scan to application files

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -111,7 +111,7 @@ jobs:
         run: |
           pip install -r requirements-test.txt
           python -m pytest --cov=. --cov-report=xml
-          bandit -r .
+          bandit -r app.py broadcast_handler.py
 
       - name: Run Terraform Tests (Backend Module)
         working-directory: infra/modules/backend


### PR DESCRIPTION
This PR fixes the CI pipeline failure caused by Bandit scanning all python files (including test files and installed pip dependencies). It restricts the scan to only the core application files (app.py and broadcast_handler.py).