### PR TITLE
fix: increase SQS visibility timeout

### DIFF
--- a/infra/modules/backend/main.tf
+++ b/infra/modules/backend/main.tf
@@ -138,6 +138,7 @@ resource "aws_sqs_queue" "broadcast_queue" {
   name = "${var.project_name}-${var.environment}-broadcast-queue"
 
   sqs_managed_sse_enabled = true
+  visibility_timeout_seconds = 300
 }
 
 # -------------------------------------------------------------------------

--- a/infra/modules/backend/main.tf
+++ b/infra/modules/backend/main.tf
@@ -137,7 +137,7 @@ resource "aws_lambda_function" "api_lambda" {
 resource "aws_sqs_queue" "broadcast_queue" {
   name = "${var.project_name}-${var.environment}-broadcast-queue"
 
-  sqs_managed_sse_enabled = true
+  sqs_managed_sse_enabled    = true
   visibility_timeout_seconds = 300
 }
 


### PR DESCRIPTION
This PR fixes the infrastructure deployment failure where the SQS queue visibility timeout (default 30s) was less than the Broadcast Lambda function timeout (60s).