### PR TITLE
Fix: Blog cover image width

### DIFF
--- a/src/pages/blog/BlogDetail.css
+++ b/src/pages/blog/BlogDetail.css
@@ -195,7 +195,6 @@
 .medium-article-cover-img {
   width: 100%;
   height: auto;
-  max-height: 600px;
   object-fit: contain;
   border-radius: 4px;
 }


### PR DESCRIPTION
Removed max-height: 600px from the blog cover image so that it perfectly matches the full-width layout of the inline architecture diagrams.