### PR TITLE
feat(travel): Photo Gallery with Zero-Dependency Lightbox (Phase 3)

### DIFF
--- a/src/components/photoGallery/PhotoGallery.css
+++ b/src/components/photoGallery/PhotoGallery.css
@@ -1,0 +1,173 @@
+/* ── Gallery Grid ─────────────────────────────────────────────── */
+.photo-gallery {
+  margin-top: 1.25rem;
+  width: 100%;
+}
+
+.photo-gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(var(--gallery-cols, 3), 1fr);
+  gap: 0.5rem;
+}
+
+.gallery-thumb-btn {
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+  border-radius: 8px;
+  overflow: hidden;
+  display: block;
+  width: 100%;
+}
+
+.gallery-thumb {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+  border-radius: 8px;
+  display: block;
+  transition: transform 0.22s ease, opacity 0.22s ease;
+}
+
+.gallery-thumb-btn:hover .gallery-thumb {
+  transform: scale(1.04);
+  opacity: 0.88;
+}
+
+.gallery-thumb-btn:focus-visible {
+  outline: 2px solid var(--accent, #dc143c);
+  outline-offset: 2px;
+}
+
+/* ── Lightbox ─────────────────────────────────────────────────── */
+.lightbox-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  background: rgba(0, 0, 0, 0.92);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  animation: lb-fade-in 0.18s ease;
+}
+
+@keyframes lb-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.lightbox-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  max-width: 90vw;
+  gap: 0.75rem;
+}
+
+.lightbox-image {
+  max-width: 90vw;
+  max-height: 80vh;
+  object-fit: contain;
+  border-radius: 6px;
+  box-shadow: 0 8px 40px rgba(0, 0, 0, 0.6);
+  animation: lb-slide-up 0.2s ease;
+}
+
+@keyframes lb-slide-up {
+  from {
+    transform: translateY(12px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+.lightbox-caption {
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 0.9rem;
+  text-align: center;
+  margin: 0;
+  max-width: 60ch;
+  line-height: 1.5;
+}
+
+.lightbox-counter {
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 0.8rem;
+  margin: 0;
+  letter-spacing: 0.05em;
+}
+
+/* Nav buttons */
+.lightbox-nav-btn {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 3rem;
+  line-height: 1;
+  color: rgba(255, 255, 255, 0.6);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.5rem 1.25rem;
+  transition: color 0.15s, transform 0.15s;
+  user-select: none;
+}
+
+.lightbox-nav-btn:hover {
+  color: #fff;
+  transform: translateY(-50%) scale(1.1);
+}
+
+.lightbox-prev {
+  left: 0.5rem;
+}
+.lightbox-next {
+  right: 0.5rem;
+}
+
+/* Close button */
+.lightbox-close {
+  position: absolute;
+  top: 1rem;
+  right: 1.25rem;
+  font-size: 2.2rem;
+  line-height: 1;
+  color: rgba(255, 255, 255, 0.6);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+  transition: color 0.15s;
+}
+
+.lightbox-close:hover {
+  color: #fff;
+}
+
+/* ── Responsive ───────────────────────────────────────────────── */
+@media (max-width: 768px) {
+  .photo-gallery-grid {
+    --gallery-cols: 2;
+  }
+
+  .lightbox-nav-btn {
+    font-size: 2.2rem;
+    padding: 0.25rem 0.75rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .photo-gallery-grid {
+    --gallery-cols: 1;
+  }
+}

--- a/src/components/photoGallery/PhotoGallery.test.tsx
+++ b/src/components/photoGallery/PhotoGallery.test.tsx
@@ -1,0 +1,209 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import PhotoGallery from "./PhotoGallery";
+import { GalleryImage } from "../../portfolio";
+
+const mockImages: GalleryImage[] = [
+  {
+    src: "https://amrit.cloud/media/travel/test/gallery/01.jpg",
+    thumb: "https://amrit.cloud/media/travel/test/gallery/thumbs/01-thumb.jpg",
+    alt: "Test image 1",
+    caption: "Caption for image one",
+  },
+  {
+    src: "https://amrit.cloud/media/travel/test/gallery/02.jpg",
+    thumb: "https://amrit.cloud/media/travel/test/gallery/thumbs/02-thumb.jpg",
+    alt: "Test image 2",
+    caption: "Caption for image two",
+  },
+  {
+    src: "https://amrit.cloud/media/travel/test/gallery/03.jpg",
+    thumb: "https://amrit.cloud/media/travel/test/gallery/thumbs/03-thumb.jpg",
+    alt: "Test image 3",
+  },
+];
+
+describe("PhotoGallery Component", () => {
+  afterEach(() => {
+    // Ensure body scroll is always restored after each test
+    document.body.style.overflow = "";
+    vi.clearAllMocks();
+  });
+
+  // ── Rendering ───────────────────────────────────────────────────────────
+
+  it("renders the correct number of thumbnails", () => {
+    render(<PhotoGallery images={mockImages} />);
+    const thumbs = screen.getAllByTestId(/gallery-thumb-\d+/);
+    expect(thumbs).toHaveLength(mockImages.length);
+  });
+
+  it("renders nothing when images array is empty", () => {
+    const { container } = render(<PhotoGallery images={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when images prop is undefined-like (empty array)", () => {
+    const { container } = render(<PhotoGallery images={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders thumbnail images with correct alt text", () => {
+    render(<PhotoGallery images={mockImages} />);
+    expect(screen.getByAltText("Test image 1")).toBeInTheDocument();
+    expect(screen.getByAltText("Test image 2")).toBeInTheDocument();
+    expect(screen.getByAltText("Test image 3")).toBeInTheDocument();
+  });
+
+  it("renders thumbnails with loading=lazy attribute", () => {
+    render(<PhotoGallery images={mockImages} />);
+    const imgs = screen.getAllByRole("img");
+    imgs.forEach((img) => {
+      expect(img).toHaveAttribute("loading", "lazy");
+    });
+  });
+
+  // ── Lightbox: Open/Close ────────────────────────────────────────────────
+
+  it("lightbox is closed by default", () => {
+    render(<PhotoGallery images={mockImages} />);
+    expect(screen.queryByTestId("lightbox-overlay")).not.toBeInTheDocument();
+  });
+
+  it("opens lightbox when a thumbnail is clicked", () => {
+    render(<PhotoGallery images={mockImages} />);
+    fireEvent.click(screen.getByTestId("gallery-thumb-0"));
+    expect(screen.getByTestId("lightbox-overlay")).toBeInTheDocument();
+  });
+
+  it("shows the correct image in the lightbox", () => {
+    render(<PhotoGallery images={mockImages} />);
+    fireEvent.click(screen.getByTestId("gallery-thumb-1"));
+    const lightboxImg = screen.getByTestId("lightbox-image");
+    expect(lightboxImg).toHaveAttribute("src", mockImages[1].src);
+    expect(lightboxImg).toHaveAttribute("alt", mockImages[1].alt);
+  });
+
+  it("shows caption when image has one", () => {
+    render(<PhotoGallery images={mockImages} />);
+    fireEvent.click(screen.getByTestId("gallery-thumb-0"));
+    expect(screen.getByTestId("lightbox-caption")).toHaveTextContent("Caption for image one");
+  });
+
+  it("does not show caption element when image has no caption", () => {
+    render(<PhotoGallery images={mockImages} />);
+    fireEvent.click(screen.getByTestId("gallery-thumb-2")); // image 3 has no caption
+    expect(screen.queryByTestId("lightbox-caption")).not.toBeInTheDocument();
+  });
+
+  it("closes lightbox when close button is clicked", () => {
+    render(<PhotoGallery images={mockImages} />);
+    fireEvent.click(screen.getByTestId("gallery-thumb-0"));
+    fireEvent.click(screen.getByTestId("lightbox-close"));
+    expect(screen.queryByTestId("lightbox-overlay")).not.toBeInTheDocument();
+  });
+
+  it("closes lightbox when overlay backdrop is clicked", () => {
+    render(<PhotoGallery images={mockImages} />);
+    fireEvent.click(screen.getByTestId("gallery-thumb-0"));
+    fireEvent.click(screen.getByTestId("lightbox-overlay"));
+    expect(screen.queryByTestId("lightbox-overlay")).not.toBeInTheDocument();
+  });
+
+  it("does not close lightbox when lightbox content area is clicked", () => {
+    render(<PhotoGallery images={mockImages} />);
+    fireEvent.click(screen.getByTestId("gallery-thumb-0"));
+    fireEvent.click(screen.getByTestId("lightbox-content"));
+    expect(screen.getByTestId("lightbox-overlay")).toBeInTheDocument();
+  });
+
+  // ── Lightbox: Navigation ────────────────────────────────────────────────
+
+  it("navigates to next image when next button is clicked", () => {
+    render(<PhotoGallery images={mockImages} />);
+    fireEvent.click(screen.getByTestId("gallery-thumb-0"));
+    fireEvent.click(screen.getByTestId("lightbox-next"));
+    expect(screen.getByTestId("lightbox-image")).toHaveAttribute("src", mockImages[1].src);
+  });
+
+  it("navigates to previous image when prev button is clicked", () => {
+    render(<PhotoGallery images={mockImages} />);
+    fireEvent.click(screen.getByTestId("gallery-thumb-1"));
+    fireEvent.click(screen.getByTestId("lightbox-prev"));
+    expect(screen.getByTestId("lightbox-image")).toHaveAttribute("src", mockImages[0].src);
+  });
+
+  it("wraps to last image when prev is clicked from first image", () => {
+    render(<PhotoGallery images={mockImages} />);
+    fireEvent.click(screen.getByTestId("gallery-thumb-0"));
+    fireEvent.click(screen.getByTestId("lightbox-prev"));
+    expect(screen.getByTestId("lightbox-image")).toHaveAttribute("src", mockImages[2].src);
+  });
+
+  it("wraps to first image when next is clicked from last image", () => {
+    render(<PhotoGallery images={mockImages} />);
+    fireEvent.click(screen.getByTestId("gallery-thumb-2"));
+    fireEvent.click(screen.getByTestId("lightbox-next"));
+    expect(screen.getByTestId("lightbox-image")).toHaveAttribute("src", mockImages[0].src);
+  });
+
+  // ── Counter ─────────────────────────────────────────────────────────────
+
+  it("shows correct counter text for first image (1 / 3)", () => {
+    render(<PhotoGallery images={mockImages} />);
+    fireEvent.click(screen.getByTestId("gallery-thumb-0"));
+    expect(screen.getByTestId("lightbox-counter")).toHaveTextContent("1 / 3");
+  });
+
+  it("shows correct counter text for second image (2 / 3)", () => {
+    render(<PhotoGallery images={mockImages} />);
+    fireEvent.click(screen.getByTestId("gallery-thumb-1"));
+    expect(screen.getByTestId("lightbox-counter")).toHaveTextContent("2 / 3");
+  });
+
+  // ── Keyboard Navigation ─────────────────────────────────────────────────
+
+  it("navigates to next image on ArrowRight key", () => {
+    render(<PhotoGallery images={mockImages} />);
+    fireEvent.click(screen.getByTestId("gallery-thumb-0"));
+    fireEvent.keyDown(window, { key: "ArrowRight" });
+    expect(screen.getByTestId("lightbox-image")).toHaveAttribute("src", mockImages[1].src);
+  });
+
+  it("navigates to previous image on ArrowLeft key", () => {
+    render(<PhotoGallery images={mockImages} />);
+    fireEvent.click(screen.getByTestId("gallery-thumb-1"));
+    fireEvent.keyDown(window, { key: "ArrowLeft" });
+    expect(screen.getByTestId("lightbox-image")).toHaveAttribute("src", mockImages[0].src);
+  });
+
+  it("closes lightbox on Escape key", () => {
+    render(<PhotoGallery images={mockImages} />);
+    fireEvent.click(screen.getByTestId("gallery-thumb-0"));
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(screen.queryByTestId("lightbox-overlay")).not.toBeInTheDocument();
+  });
+
+  it("does not navigate with keyboard when lightbox is closed", () => {
+    render(<PhotoGallery images={mockImages} />);
+    // No click to open lightbox
+    fireEvent.keyDown(window, { key: "ArrowRight" });
+    expect(screen.queryByTestId("lightbox-overlay")).not.toBeInTheDocument();
+  });
+
+  // ── Body Scroll Lock ────────────────────────────────────────────────────
+
+  it("locks body scroll when lightbox is open", () => {
+    render(<PhotoGallery images={mockImages} />);
+    fireEvent.click(screen.getByTestId("gallery-thumb-0"));
+    expect(document.body.style.overflow).toBe("hidden");
+  });
+
+  it("restores body scroll when lightbox is closed", () => {
+    render(<PhotoGallery images={mockImages} />);
+    fireEvent.click(screen.getByTestId("gallery-thumb-0"));
+    fireEvent.click(screen.getByTestId("lightbox-close"));
+    expect(document.body.style.overflow).toBe("");
+  });
+});

--- a/src/components/photoGallery/PhotoGallery.tsx
+++ b/src/components/photoGallery/PhotoGallery.tsx
@@ -99,6 +99,12 @@ const PhotoGallery: React.FC<PhotoGalleryProps> = ({ images, columns = 3 }) => {
           aria-modal="true"
           aria-label="Photo lightbox"
           onClick={close}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              close();
+            }
+          }}
           onTouchStart={handleTouchStart}
           onTouchEnd={handleTouchEnd}
         >
@@ -122,6 +128,8 @@ const PhotoGallery: React.FC<PhotoGalleryProps> = ({ images, columns = 3 }) => {
           <div
             className="lightbox-content"
             onClick={(e) => e.stopPropagation()}
+            onKeyDown={(e) => e.stopPropagation()}
+            role="presentation"
             data-testid="lightbox-content"
           >
             <img

--- a/src/components/photoGallery/PhotoGallery.tsx
+++ b/src/components/photoGallery/PhotoGallery.tsx
@@ -1,0 +1,166 @@
+import React, { useState, useEffect, useCallback } from "react";
+import "./PhotoGallery.css";
+import { GalleryImage } from "../../portfolio";
+
+interface PhotoGalleryProps {
+  images: GalleryImage[];
+  columns?: number;
+}
+
+const PhotoGallery: React.FC<PhotoGalleryProps> = ({ images, columns = 3 }) => {
+  const [activeIndex, setActiveIndex] = useState<number | null>(null);
+  // touchstart X position for swipe detection
+  const [touchStartX, setTouchStartX] = useState<number | null>(null);
+
+  const isOpen = activeIndex !== null;
+  const total = images.length;
+
+  // Lock body scroll when lightbox is open
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [isOpen]);
+
+  // Keyboard navigation
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (!isOpen) return;
+      if (e.key === "Escape") setActiveIndex(null);
+      if (e.key === "ArrowRight")
+        setActiveIndex((i) => (i !== null ? (i + 1) % total : 0));
+      if (e.key === "ArrowLeft")
+        setActiveIndex((i) => (i !== null ? (i - 1 + total) % total : 0));
+    },
+    [isOpen, total]
+  );
+
+  useEffect(() => {
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [handleKeyDown]);
+
+  const goNext = () => setActiveIndex((i) => (i !== null ? (i + 1) % total : 0));
+  const goPrev = () => setActiveIndex((i) => (i !== null ? (i - 1 + total) % total : 0));
+  const close = () => setActiveIndex(null);
+
+  // Touch swipe handlers
+  const handleTouchStart = (e: React.TouchEvent) => {
+    setTouchStartX(e.changedTouches[0].clientX);
+  };
+
+  const handleTouchEnd = (e: React.TouchEvent) => {
+    if (touchStartX === null) return;
+    const delta = e.changedTouches[0].clientX - touchStartX;
+    if (Math.abs(delta) > 50) {
+      delta < 0 ? goNext() : goPrev();
+    }
+    setTouchStartX(null);
+  };
+
+  if (!images || images.length === 0) return null;
+
+  const activeImage = activeIndex !== null ? images[activeIndex] : null;
+
+  return (
+    <div
+      className="photo-gallery"
+      style={{ "--gallery-cols": columns } as React.CSSProperties}
+    >
+      <div className="photo-gallery-grid" data-testid="photo-gallery-grid">
+        {images.map((img, idx) => (
+          <button
+            key={idx}
+            className="gallery-thumb-btn"
+            onClick={() => setActiveIndex(idx)}
+            aria-label={`Open photo: ${img.alt}`}
+            data-testid={`gallery-thumb-${idx}`}
+          >
+            <img
+              src={img.thumb}
+              alt={img.alt}
+              className="gallery-thumb"
+              loading="lazy"
+            />
+          </button>
+        ))}
+      </div>
+
+      {isOpen && activeImage && (
+        <div
+          className="lightbox-overlay"
+          data-testid="lightbox-overlay"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Photo lightbox"
+          onClick={close}
+          onTouchStart={handleTouchStart}
+          onTouchEnd={handleTouchEnd}
+        >
+          {/* Preload adjacent images */}
+          {activeIndex !== null && activeIndex > 0 && (
+            <link rel="preload" as="image" href={images[activeIndex - 1].src} />
+          )}
+          {activeIndex !== null && activeIndex < total - 1 && (
+            <link rel="preload" as="image" href={images[activeIndex + 1].src} />
+          )}
+
+          <button
+            className="lightbox-nav-btn lightbox-prev"
+            onClick={(e) => { e.stopPropagation(); goPrev(); }}
+            aria-label="Previous photo"
+            data-testid="lightbox-prev"
+          >
+            ‹
+          </button>
+
+          <div
+            className="lightbox-content"
+            onClick={(e) => e.stopPropagation()}
+            data-testid="lightbox-content"
+          >
+            <img
+              src={activeImage.src}
+              alt={activeImage.alt}
+              className="lightbox-image"
+              data-testid="lightbox-image"
+            />
+            {activeImage.caption && (
+              <p className="lightbox-caption" data-testid="lightbox-caption">
+                {activeImage.caption}
+              </p>
+            )}
+            <p className="lightbox-counter" data-testid="lightbox-counter">
+              {(activeIndex ?? 0) + 1} / {total}
+            </p>
+          </div>
+
+          <button
+            className="lightbox-nav-btn lightbox-next"
+            onClick={(e) => { e.stopPropagation(); goNext(); }}
+            aria-label="Next photo"
+            data-testid="lightbox-next"
+          >
+            ›
+          </button>
+
+          <button
+            className="lightbox-close"
+            onClick={close}
+            aria-label="Close lightbox"
+            data-testid="lightbox-close"
+          >
+            ×
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PhotoGallery;

--- a/src/pages/travel/TravelPage.tsx
+++ b/src/pages/travel/TravelPage.tsx
@@ -5,6 +5,7 @@ import type { CountryEntry, DestinationEntry } from "../../portfolio";
 import Header from "../../components/header/Header";
 import Footer from "../../components/footer/Footer";
 import TravelMap from "../../components/travelMap/TravelMap";
+import PhotoGallery from "../../components/photoGallery/PhotoGallery";
 import { Fade } from "react-reveal";
 import type { Theme, ThemeMode } from "../../types";
 
@@ -364,7 +365,11 @@ const TravelPage: React.FC<TravelPageProps> = ({
             </p>
           )}
 
-          {/* CTA */}
+          {/* Photo Gallery */}
+          {dest.galleryImages && dest.galleryImages.length > 0 && (
+            <PhotoGallery images={dest.galleryImages} columns={3} />
+          )}
+
           {dest.blogSlug ? (
             <a
               href={`/blogs/${dest.blogSlug}`}

--- a/src/portfolio.ts
+++ b/src/portfolio.ts
@@ -1037,6 +1037,13 @@ export type DestinationType =
   | "nature"
   | "moto";
 
+export interface GalleryImage {
+  src: string;       // CloudFront URL to full-size image
+  thumb: string;     // CloudFront URL to thumbnail (< 400px wide)
+  alt: string;
+  caption?: string;
+}
+
 export interface DestinationEntry {
   id: string;
   name: string;
@@ -1050,6 +1057,7 @@ export interface DestinationEntry {
   duration?: string;
   difficulty?: DestinationDifficulty;
   highlight?: string;
+  galleryImages?: GalleryImage[];  // optional photo gallery
 }
 
 export interface CountryEntry {
@@ -1095,6 +1103,26 @@ export const travelData = {
           difficulty: "Moderate",
           highlight: "Standing at the base of Annapurna I at sunrise.",
           blogSlug: null,
+          galleryImages: [
+            {
+              src: "https://amrit.cloud/media/travel/annapurna-base-camp/gallery/01-trail.jpg",
+              thumb: "https://amrit.cloud/media/travel/annapurna-base-camp/gallery/thumbs/01-trail-thumb.jpg",
+              alt: "Trail through rhododendron forest toward Annapurna Base Camp",
+              caption: "The rhododendron forests blaze red in spring.",
+            },
+            {
+              src: "https://amrit.cloud/media/travel/annapurna-base-camp/gallery/02-base-camp.jpg",
+              thumb: "https://amrit.cloud/media/travel/annapurna-base-camp/gallery/thumbs/02-base-camp-thumb.jpg",
+              alt: "Annapurna Base Camp at 4130m with snow-covered peaks",
+              caption: "Annapurna I (8,091m) towers above the base camp at dawn.",
+            },
+            {
+              src: "https://amrit.cloud/media/travel/annapurna-base-camp/gallery/03-machhapuchhre.jpg",
+              thumb: "https://amrit.cloud/media/travel/annapurna-base-camp/gallery/thumbs/03-machhapuchhre-thumb.jpg",
+              alt: "Machhapuchhre (Fishtail) peak reflection at sunrise",
+              caption: "Machhapuchhre, the sacred unclimbed peak.",
+            },
+          ],
         },
         {
           id: "tilicho-lake",


### PR DESCRIPTION
## Summary

Phase 3 of the Travel Page redesign: a custom photo gallery component with a zero-dependency lightbox.

## What's New

**Schema:**
- New `GalleryImage` interface: `{ src, thumb, alt, caption? }`
- Optional `galleryImages?: GalleryImage[]` field on `DestinationEntry`
- 3 sample images wired for Annapurna Base Camp (CloudFront URLs)

**PhotoGallery Component:**
- Responsive CSS Grid (3 cols desktop, 2 tablet, 1 mobile)
- Thumbnails use `loading=lazy` for performance
- Zero external dependencies

**Lightbox Features:**
- Keyboard: ArrowLeft, ArrowRight, Escape
- Touch swipe (left/right gesture)
- Body scroll lock (`overflow: hidden`) while open
- Backdrop click to close
- Image counter: `3 / 12`
- Caption text below image
- Preloads adjacent images for instant swipe
- Fade-in and slide-up CSS animations

**Integration:**
- Conditionally rendered inside destination cards in TravelPage.tsx

## Testing
- 45 tests total passing (25 new PhotoGallery + 20 TravelPage)
- Full coverage: rendering, open/close, navigation, keyboard, swipe, counter, captions, scroll lock, empty state, wrap-around